### PR TITLE
Fix bug when the tool opens while the game is already running

### DIFF
--- a/src/Pokebot.cs
+++ b/src/Pokebot.cs
@@ -65,7 +65,7 @@ namespace Pokebot
 
         public bool IsReady
         {
-            get => IsLoaded && IsRomLoaded && APIContainer != null && GameVersion != null;
+            get => IsRomLoaded && APIContainer != null && GameVersion != null; //&& IsLoaded
         }
 
         public GameVersion? GameVersion { get; private set; }
@@ -313,7 +313,7 @@ namespace Pokebot
         private void ExecuteBot(GameState state)
         {
             //Main call for bots
-            if (IsReady && Bot != null)
+            if (Bot != null)
             {
                 Bot.UpdateUI(state);
 

--- a/src/Pokebot.csproj
+++ b/src/Pokebot.csproj
@@ -8,7 +8,7 @@
 	<PropertyGroup>
 		<Version>1.1.0</Version>
 		<AssemblyVersion>1.0.0</AssemblyVersion>
-		<FileVersion>1.1.0</FileVersion>
+		<FileVersion>1.1.1</FileVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)' == 'Release' ">
 		<VersionSuffix>release</VersionSuffix>


### PR DESCRIPTION
FIX:
- Bug when the tool opens while the game is already running. Watchers and bot didn't load correctly.